### PR TITLE
Performance tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ RUN ln -s /usr/src/app/docker/config.json /usr/src/app/config.json
 CMD cat .make-uploads-folders | xargs mkdir -p \
 && ./nodebb upgrade \
 && echo 1 > pidfile \
-&& exec node loader.js
+&& exec node --perf-basic-prof-only-functions loader.js

--- a/collect-stacks.bash
+++ b/collect-stacks.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+DOCKER_PID=$1
+HOST_PID=$2
+
+docker cp wtdwtf-nodebb:/tmp/perf-$DOCKER_PID.map /tmp/perf-$HOST_PID.map
+chown root /tmp/perf-$HOST_PID.map
+perf record -F 99 -p $HOST_PID -g -- sleep 30
+perf script > nodestacks

--- a/setup.bash
+++ b/setup.bash
@@ -36,8 +36,10 @@ else
 nodebb-upstream.conf for a webserver running on the host."
 fi
 
+
 # pull the NodeBB image
-docker pull boomzillawtf/tdwtf
+#docker pull boomzillawtf/tdwtf
+docker build -t boomzillawtf/tdwtf -f Dockerfile .
 
 # create a Docker network
 docker network create --subnet 172.21.1.0/24 wtdwtf

--- a/setup.bash
+++ b/setup.bash
@@ -38,8 +38,7 @@ fi
 
 
 # pull the NodeBB image
-#docker pull boomzillawtf/tdwtf
-docker build -t boomzillawtf/tdwtf -f Dockerfile .
+docker pull boomzillawtf/tdwtf
 
 # create a Docker network
 docker network create --subnet 172.21.1.0/24 wtdwtf


### PR DESCRIPTION
Add `--perf-basic-prof-only-functions` flag to node invocation to allow us to get stack traces when a node process goes to 100% CPU.

Also `collect-stacks.bash` script for collecting the stack traces.