### PR TITLE
Show ID for downvotes from users in group Public Downvoters.

### DIFF
--- a/plugins/nodebb-plugin-tdwtf-customizations/index.js
+++ b/plugins/nodebb-plugin-tdwtf-customizations/index.js
@@ -43,7 +43,11 @@ SocketPosts.getVoters = async function (socket, data) {
 
 	// TDWTF: Added:
 	if (!isAdminOrMod) {
-		downvoteUids = Array(downvoteUids.length).fill(14);
+		for (i = 0; i < downvoteUids.length; ++i) {
+			if (!Groups.isMember(downvoteUids[i], 'Public Downvoters', done)) {
+				downvoteUids[i] = 14;
+			}
+		}
 	}
 	// End Added
 


### PR DESCRIPTION
The group name is currently "Public Downvoters" because that's simple and descriptive. I kinda wanted to go with something more "in" for us, like "I am not boomzilla", but I didn't because I figured that it was contrary to the everyone-is-boomzilla in-joke and that newbies might not understand what is the purpose of the group.
The group will need to be created, but this code should work even without the group, if Groups.isMember() returns some falsy value when a group with the provided name does not exist.